### PR TITLE
Resize all charts

### DIFF
--- a/search-sentiments-map/public/index.html
+++ b/search-sentiments-map/public/index.html
@@ -12,13 +12,15 @@
     <script src="scripts/current-data-script.js"></script>
     <script src="scripts/map-script.js"></script>
     <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <!-- Use version 45 to allow for chart ticks to be drawn when the div container is hidden. Needs to load before any functions are called.  -->
+    <script>google.charts.load('45', {'packages':['corechart']});</script>
     <script src="scripts/modal-script.js"></script>
     <script src="scripts/trends-script.js"></script>
     <script src="scripts/timeline-script.js"></script>
     <script src="scripts/search-topic-script.js"></script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAeg112BVJlrJDHxRoHpqNU3NVMNJu91wg"></script>
   </head>
-  <body onload="initMap(); updateTrends(); countrySelectSetUp();">    
+  <body onload="initMap(); updateTrends(); countrySelectSetUp(); loadCharts()">    
     <div class="modal fade" id="region-info-modal" tabindex="-1" role="dialog" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
@@ -33,13 +35,13 @@
                   <a class="nav-link active" href="#search-results-tab" aria-controls="search-results-tab" role="tab" data-toggle="tab">Search Results</a>
                 </li>
                 <li role="presentation" class="nav-item">
-                  <a class="nav-link" href="#sentiment-chart-tab" aria-controls="sentiment-chart-tab" role="tab" data-toggle="tab">Sentiment Chart</a>
+                  <a class="nav-link" id="sentiment-chart-link" href="#sentiment-chart-tab" aria-controls="sentiment-chart-tab" role="tab" data-toggle="tab">Sentiment Chart</a>
                 </li>
                 <li role="presentation" class="nav-item">
                   <a class="nav-link" href="#top-trends-tab" aria-controls="top-trends-tab" role="tab" data-toggle="tab">Top Trends</a>
                 </li>
                 <li role="presentation" class="nav-item">
-                    <a class="nav-link" href="#popularity-timeline-tab" aria-controls="popularity-timeline-tab" role="tab" data-toggle="tab">Popularity Timeline</a>
+                    <a class="nav-link" id="popularity-timeline-link"href="#popularity-timeline-tab" aria-controls="popularity-timeline-tab" role="tab" data-toggle="tab">Popularity Timeline</a>
                 </li>
               </ul>
               <div class="tab-content">

--- a/search-sentiments-map/public/index.html
+++ b/search-sentiments-map/public/index.html
@@ -20,7 +20,7 @@
     <script src="scripts/search-topic-script.js"></script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAeg112BVJlrJDHxRoHpqNU3NVMNJu91wg"></script>
   </head>
-  <body onload="initMap(); updateGlobalTrendsAndDisplayFirst(); countrySelectSetUp(); loadCharts();">
+  <body onload="initMap(); updateGlobalTrendsAndDisplayFirst(); countrySelectSetUp(); setCharts();">
     <div class="modal fade" id="region-info-modal" tabindex="-1" role="dialog" aria-hidden="true">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
@@ -41,7 +41,7 @@
                   <a class="nav-link" href="#top-trends-tab" aria-controls="top-trends-tab" role="tab" data-toggle="tab">Top Trends</a>
                 </li>
                 <li role="presentation" class="nav-item">
-                    <a class="nav-link" id="popularity-timeline-link"href="#popularity-timeline-tab" aria-controls="popularity-timeline-tab" role="tab" data-toggle="tab">Popularity Timeline</a>
+                    <a class="nav-link" id="popularity-timeline-link" href="#popularity-timeline-tab" aria-controls="popularity-timeline-tab" role="tab" data-toggle="tab">Popularity Timeline</a>
                 </li>
               </ul>
               <div class="tab-content">

--- a/search-sentiments-map/public/index.html
+++ b/search-sentiments-map/public/index.html
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
     <script src="scripts/current-data-script.js"></script>
     <script src="scripts/map-script.js"></script>
     <script src="https://www.gstatic.com/charts/loader.js"></script>
@@ -132,7 +134,5 @@
         <option value="us">United States</option>
       </select>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/search-sentiments-map/public/index.html
+++ b/search-sentiments-map/public/index.html
@@ -8,6 +8,7 @@
     <!-- Bootstrap CSS. -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="scripts/current-data-script.js"></script>
     <script src="scripts/map-script.js"></script>
     <script src="https://www.gstatic.com/charts/loader.js"></script>
@@ -127,7 +128,6 @@
         <option value="us">United States</option>
       </select>
     </div>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
   </body>

--- a/search-sentiments-map/public/scripts/modal-script.js
+++ b/search-sentiments-map/public/scripts/modal-script.js
@@ -127,7 +127,6 @@ async function displayTopResultsForCurrentTrend(countryCode) {
   resultElement.innerHTML = '';
   let countryData = getCurrentSearchData().dataByCountry
       .filter(data => data.country === countryCode);
- 
   // Handle case where there are no search results for the topic.
   if (countryData.length === 0 ||
       countryData[0].averageSentiment === NO_RESULTS_DEFAULT_SCORE) {
@@ -137,7 +136,6 @@ async function displayTopResultsForCurrentTrend(countryCode) {
         countryData[0].interest + '</b><br>';
     resultElement.innerHTML += '<b>Average Sentiment Score: ' + 
         countryData[0].averageSentiment.toFixed(1) + '</b><br>';
- 
     // Get search results for the specified country.
     let results = countryData[0].results;
     for (let i = 0; i < results.length; i++) {
@@ -148,7 +146,6 @@ async function displayTopResultsForCurrentTrend(countryCode) {
             // i + 1 shows the index for each search result.
             resultElement.innerHTML += (i + 1).toString() + '. ' + '<a href=' + 
                 results[i].link + '>' + results[i].htmlTitle + '</a><br>';
-
             // Check that positive and negative words are detected by the Node.js 
             // sentiment API.
             if (sentimentWordsResult != null) {

--- a/search-sentiments-map/public/scripts/modal-script.js
+++ b/search-sentiments-map/public/scripts/modal-script.js
@@ -114,7 +114,7 @@ function setCountryTrends(countryCode) {
 function toggleDisplay(id) {
   document.getElementById(id).classList.toggle('hidden');
 }
- 
+
 /** 
  * Displays the top results in a country for the current search trend on modal
  * and show positive words if the sign of the sentiment score is positive,
@@ -127,6 +127,7 @@ async function displayTopResultsForCurrentTrend(countryCode) {
   resultElement.innerHTML = '';
   let countryData = getCurrentSearchData().dataByCountry
       .filter(data => data.country === countryCode);
+
   // Handle case where there are no search results for the topic.
   if (countryData.length === 0 ||
       countryData[0].averageSentiment === NO_RESULTS_DEFAULT_SCORE) {
@@ -136,6 +137,7 @@ async function displayTopResultsForCurrentTrend(countryCode) {
         countryData[0].interest + '</b><br>';
     resultElement.innerHTML += '<b>Average Sentiment Score: ' + 
         countryData[0].averageSentiment.toFixed(1) + '</b><br>';
+        
     // Get search results for the specified country.
     let results = countryData[0].results;
     for (let i = 0; i < results.length; i++) {
@@ -146,6 +148,7 @@ async function displayTopResultsForCurrentTrend(countryCode) {
             // i + 1 shows the index for each search result.
             resultElement.innerHTML += (i + 1).toString() + '. ' + '<a href=' + 
                 results[i].link + '>' + results[i].htmlTitle + '</a><br>';
+
             // Check that positive and negative words are detected by the Node.js 
             // sentiment API.
             if (sentimentWordsResult != null) {
@@ -206,7 +209,7 @@ function highlightWords(
 function setPopularityTimeline() {
   const popularityTimelineElement = document.getElementById('popularity-timeline-tab');
   popularityTimelineElement.innerHTML = '';
-  postTrendsToGetPopularityTimelineData(getCurrentSearchData().topic, countryCode)
+  postTrendsToGetPopularityTimelineData()
       .then(timelineJSON => {
         if (timelineJSON.default.timelineData.length === 0) {
           popularityTimelineElement.innerText = 
@@ -227,7 +230,8 @@ function setPopularityTimeline() {
  * @param {string} topic The search topic that the popularity timeline is based on.
  * @return {Promise} The promise which resolves to the the timeline JSON data.
  */
-function postTrendsToGetPopularityTimelineData(topic) {
+function postTrendsToGetPopularityTimelineData() {
+  let topic = getCurrentSearchData().topic;
   // Check if country code and topic is in the cache already.
   if (!cachePopularityTimelineData[topic]) {
     cachePopularityTimelineData[topic] = {};
@@ -294,7 +298,7 @@ function drawPopularityTimeline(timelineData, popularityTimelineElement, topic) 
   let chart = new google.visualization.LineChart(popularityTimelineElement);
   chart.draw(data, options);
 }
- 
+
 /** 
  * Sets sentiment chart of search results for the current country on the modal.
  */
@@ -319,7 +323,7 @@ function setSentimentChartForCurrentTrend() {
         '<i><br>';
   }
 }
- 
+
 /** 
  * Draws a sentiment chart and adds it to the given element. 
  * @param {Object} chartElement Tab element to update with the sentiment chart.
@@ -333,7 +337,7 @@ function drawSentimentChart(chartElement, results) {
         sentimentItem.push(NEGATIVE_COLOR);
     sentimentDataArray.push(sentimentItem);
   }
- 
+
   let sentimentDataTable = google.visualization.arrayToDataTable(sentimentDataArray);
   let view = new google.visualization.DataView(sentimentDataTable);
   view.setColumns([0, 1, {
@@ -342,7 +346,7 @@ function drawSentimentChart(chartElement, results) {
     type: 'string',
     role: 'annotation',
   }, 2]);
-  
+
   let options = {
     bar: {groupWidth: '55%'},
     legend: {position: 'none'},

--- a/search-sentiments-map/public/style.css
+++ b/search-sentiments-map/public/style.css
@@ -221,3 +221,12 @@ input:checked + .slider:before {
   max-height: 200px;
   overflow-y: auto;
 }
+
+/* .modal-content,
+.modal-body {
+  width: 100vw;
+}
+
+div[role=tabpanel] {
+  width: 100vw;
+} */

--- a/search-sentiments-map/public/style.css
+++ b/search-sentiments-map/public/style.css
@@ -242,12 +242,3 @@ input:checked + .slider:before {
   max-height: 200px;
   overflow-y: auto;
 }
-
-/* .modal-content,
-.modal-body {
-  width: 100vw;
-}
-
-div[role=tabpanel] {
-  width: 100vw;
-} */


### PR DESCRIPTION
Enable resizing of font size/ actual charts themselves when window is resized, wait until user actually stops resizing to set charts. Add cacheing to make sure that there aren't too many post requests and callings to the trends api to get popularity timeline data for the timeline when resizing.